### PR TITLE
Closes#24 Removing persistence and vacuum configurable

### DIFF
--- a/src/main/scala/com/goibibo/sqlshift/alerting/MailAPI.scala
+++ b/src/main/scala/com/goibibo/sqlshift/alerting/MailAPI.scala
@@ -52,8 +52,7 @@ class MailAPI(mailParams: MailParams) {
                 "<th size=6>Mysql table_name</th>" +
                 "<th size=6>Redshift schema</th>" +
                 "<th size=6>Status</th>" +
-                "<th size=6>Load Time(ms)</th>" +
-                "<th size=6>Store Time(ms)</th>" +
+                "<th size=6>Migration Time(sec)</th>" +
                 "<th size=6>Error</th></tr>"
 
         logger.info(s"Mail to: '${mailParams.to}' and cc: '${mailParams.cc}'")
@@ -71,8 +70,7 @@ class MailAPI(mailParams: MailParams) {
                     "<td bgcolor='#E0FFFF'>" + appConf.mysqlConf.tableName + "</td>" +
                     "<td bgcolor='#F5F5DC'>" + appConf.redshiftConf.schema + "</td>" +
                     "<td bgcolor='#E0FFFF'>" + appConf.status.get.isSuccessful + "</td>" +
-                    "<td bgcolor='#E0FFFF'>" + appConf.migrationTime.get.loadTime + "</td>" +
-                    "<td bgcolor='#E0FFFF'>" + appConf.migrationTime.get.storeTime + "</td>"
+                    "<td bgcolor='#E0FFFF'>" + appConf.migrationTime.get + "</td>"
 
             if (appConf.status.get.isSuccessful) {
                 successCnt += 1

--- a/src/main/scala/com/goibibo/sqlshift/models/Configurations.scala
+++ b/src/main/scala/com/goibibo/sqlshift/models/Configurations.scala
@@ -1,6 +1,6 @@
 package com.goibibo.sqlshift.models
 
-import com.goibibo.sqlshift.models.InternalConfs.{InternalConfig, MigrationTime}
+import com.goibibo.sqlshift.models.InternalConfs.InternalConfig
 
 /**
   * Project: mysql-redshift-loader
@@ -40,7 +40,7 @@ private[sqlshift] object Configurations {
                                 s3Conf: S3Config,
                                 internalConfig: InternalConfig,
                                 status: Option[Status] = None,
-                                migrationTime: Option[MigrationTime]= None) {
+                                migrationTime: Option[Double]= None) {
 
         override def toString: String = {
             val mysqlString: String = "\tmysql-db : " + mysqlConf.db + "\n\tmysql-table : " + mysqlConf.tableName

--- a/src/main/scala/com/goibibo/sqlshift/models/InternalConfs.scala
+++ b/src/main/scala/com/goibibo/sqlshift/models/InternalConfs.scala
@@ -69,12 +69,4 @@ private[sqlshift] object InternalConfs {
                               mapPartitions: Option[Int] = None,
                               reducePartitions: Option[Int] = None) extends InternalConf
 
-    case class MigrationTime(loadTime: Double,
-                             storeTime: Double) {
-
-        override def toString: String = {
-            s"""{ LoadTime: $loadTime sec, StoreTime: $storeTime sec}"""
-        }
-    }
-
 }


### PR DESCRIPTION
Unnecessary RDD count to find load time and because of this we are persisting RDD on disk.
This might also create memory issue like disk full if table size is greater than disk.
This also increases time of complete process first loading and then copy the persisted the copied table.